### PR TITLE
Relax peerDependencies to work with react-docgen 3 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/nerdlabs/react-docgen-displayname-handler.git"
   },
   "peerDependencies": {
-    "react-docgen": "2.x"
+    "react-docgen": "2.x || ^3.0.0-beta"
   },
   "dependencies": {
     "recast": "0.11.12"


### PR DESCRIPTION
This should remove an npm warning when using react-docgen-displayname-handler with react-docgen 3 beta.
